### PR TITLE
rename: todo-item.component.css

### DIFF
--- a/adding_style.md
+++ b/adding_style.md
@@ -147,7 +147,7 @@ Add the following style to `input.component.css`:
 }
 ```
 
-Add the following style to `todo-item.component.css`:
+Add the following style to `item.component.css`:
 ```css
 .todo-item {
   padding: 10px 0;


### PR DESCRIPTION
In the Adding styles section there is references for: `todo-item.component.css` for styling a todo item.
In the code it is actually exists as: `item.component.css`