### PR TITLE
Tip changes needs to include input as well

### DIFF
--- a/element_ref_-.md
+++ b/element_ref_-.md
@@ -61,7 +61,13 @@ Next on, we'll build the list of todo items.
 Just like we did in the previous chapter, when we logged $event, you can do the same with `#inputElement`. Change the method `changeTitle` so it will receive the whole element reference and log it to the console:
 
 ```html
+<input [value]="title"              
+       (keyup.enter)="changeTitle(inputElement)"
+       #inputElement>
+
 <button (click)="changeTitle(inputElement)">
+  Save
+</button>
 ```
 ```ts
 changeTitle(inputElementReference): void {


### PR DESCRIPTION
Tip only directs changes to the button element via using `inputElement` this leave
the input with `changeTitle($event.target.value)`, so not updated with the current changes that are suggested by the TIP.

Causing the tutorial to look broken.

Therefor is snipped need to includes changes not only with button but also with input