### PR TITLE
Updating the GIthub Deploy to a modern alternative

### DIFF
--- a/deploy_to_githubpages.md
+++ b/deploy_to_githubpages.md
@@ -1,18 +1,43 @@
-# Deploy to GithubPages
-
-#### Warning: Angular-CLI command for deploying to Github Pages has been removed. [See discussion here](https://github.com/angular/angular-cli/pull/4385)
-By deploying to Github pages your app will have a host and will live and run on the Web. Everyone will be able to see and use it. 
-
-Angular-CLI makes it really easy for us to deploy to Github Pages - you can do so with a single command. But you have to prepare a few things first:
+ # Deploy your App to Github Pages
+To deploy our changes to Github pages we will use the angular-cli-ghpages packagea
+https://github.com/angular-buch/angular-cli-ghpages 
 
 * You need to have a Github user
-* You need to connect your Github user to your computer using a key
+* You need to create a repostiroy for your project.
 * You need to commit all the changes you made in the project
+* You need to install angular-cli-ghpages
 
-After completing these steps, run this command: 
+## Creating a Github user
+If you already have a Github user you can skip this step.
+To Create a Github user go to Github: https://github.com/
+Fill the regetration form and make sure to validate your email address.
 
+## Create your App repository
+After loggin in to Github.
+Click on the `Start a project` button, and name the repository `ng-girls-todo` or any other name you like.
+
+## Connecting your repository
+
+Commit all your changes by runing this command in your project directory.
 ```
-ng github-pages:deploy --message "Deploying first version to Github Pages"
+git add -A && git commit -m "Your Message"
 ```
 
-You will be asked to create and connect a Github repository for your project. This will happen only in the first time you deploy. 
+Run the following command to connect your code to your repository.
+make sure to replace the {YOUR_USERNAME} and {YOUR_REPO} with your github username and repository name.
+```
+git remote add origin https://github.com/{YOUR_USERNAME}/{YOUR_REPO}.git
+git push -u origin master
+```
+
+## Deploying to Github Pages
+First install angular-cli-ghpages.
+```
+npm i -g angular-cli-ghpages
+```
+Then Simply Run:
+```
+ng build --prod
+angular-cli-ghpages
+```
+For more information see https://github.com/angular-buch/angular-cli-ghpages.


### PR DESCRIPTION
Since the command was removed from the Angular CLI, I still think it a nice step to be able to deploy your app.
I have added instruction to use "angular-cli-ghpages" as an alternative for the removed CLI command.