### PR TITLE
change private to public and remove typing

### DIFF
--- a/a_new_component.md
+++ b/a_new_component.md
@@ -64,7 +64,7 @@ We will add some content to our new component. First, add a `title` member which
 
 ```ts
 export class InputComponent implements OnInit {
-  private title: string = '';
+  public title = '';
   ...
 ```
 

--- a/class.md
+++ b/class.md
@@ -50,14 +50,14 @@ In TypeScript we must declare members of the class either in the class body outs
 
 You can declare the property without initializing it:
 ```ts
-private title: string;
+public title: string;
 ```
 Then you can assign a value at a later stage, for example in the constructor or in the ngOnInit method. When referencing a member of the class from within a class method you must prefix it with `this`. It's a special property that points at the current instance. 
 
 Try setting a different value for `title` from inside the constructor. See the result in the browser:
 
 ```ts
-private title: string = 'my title';
+public title: string = 'my title';
 
 constructor() { 
   this.title = 'Hello World';


### PR DESCRIPTION
It needs to be public for AOT and webstorm complains about that.
Also tslint complains about : string, because typescript is super smart and will see that it is a string because of the instanciating