### PR TITLE
Fix issues with versioning, GitBook render, GH deploy, typos, etc.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,7 +19,7 @@
 * [Add more abilities to service](add_more_abilities_to_service.md)
 * [Local storage](local_storage.md)
 * [Remove item](remove_item.md)
-* [Add a checkbox](add_a_checkbox.md)
+* [Adding a checkbox](adding_a_checkbox.md)
 * [Deploy to GithubPages](deploy_to_githubpages.md)
 * [Enrich the todo-item component](enrich_the_todo-item_component.md)
 * [Appendix 1: Generating a new project](generating_a_new_project.md)

--- a/adding_a_checkbox.md
+++ b/adding_a_checkbox.md
@@ -46,6 +46,7 @@ Let's add this NgClass directive to our todo title now:
 ```
 
 And finally, add the css to our item.component.css file
+
 ```css
   .todo-complete {
     text-decoration: line-through;

--- a/adding_a_checkbox.md
+++ b/adding_a_checkbox.md
@@ -3,12 +3,13 @@
 We are now able to interact with our todo list by removing items. But what if we want to complete items and still be able to see them on our list, for example, have a line-strike through the todo title? Enter the checkbox!
 
 We will look at:
+
 * Adding a checkbox
 * Adding functionality when you click the checkbox so that a CSS class, which adds a strike-through style, is added to our todo items
 * Edit the todo title so that it will respond to the checkbox
 * Adding a new CSS Class
 
-Let's go ahead and add a checkbox into our item.component.ts file. Place the following code right before the <p> tag containing {{ todoItem.title}}:
+Let's go ahead and add a checkbox into our item.component.ts file. Place the following code right before the `<p>` tag containing `{{ todoItem.title}}`:
 
 ```html
   <input type="checkbox"/>

--- a/adding_a_checkbox.md
+++ b/adding_a_checkbox.md
@@ -22,7 +22,7 @@ Now, in order for the checkbox to do anything we need to add a click event which
 When we click on the checkbox it will run the completeItem() function. Let's talk about what this function needs to accomplish. We want to be able to toggle some CSS styling on the todo title so that when the checkbox is checked it will have a line-strike through it, and no line-strike when unchecked. In order to achieve this we will toggle a variable to be either true or false to represent checked or unchecked states. Add the following code to the ItemComponent class:
 
 ```js
-private isComplete: boolean = false;
+isComplete: boolean = false;
 
 completeItem() {
   this.isComplete = !this.isComplete;

--- a/adding_style.md
+++ b/adding_style.md
@@ -182,7 +182,7 @@ Note: Don't forget to put the CSS-classes to the templace-code of your specified
  @Component({
     ...
     template: `
-          <button class="btn btnRed" (click)="removeItem()">
+          <button class="btn btn-red" (click)="removeItem()">
           `,
 ```
 You can change the style as you wish - the size of elements, the colors - however you'd like!

--- a/deploy_to_githubpages.md
+++ b/deploy_to_githubpages.md
@@ -13,7 +13,7 @@ To Create a Github user go to Github: https://github.com/
 Fill the regetration form and make sure to validate your email address.
 
 ## Create your App repository
-After loggin in to Github.
+After logging in to Github.
 Click on the `Start a project` button, and name the repository `ng-girls-todo` or any other name you like.
 
 ## Connecting your repository

--- a/deploy_to_githubpages.md
+++ b/deploy_to_githubpages.md
@@ -32,16 +32,17 @@ git push -u origin master
 
 ## Deploying to Github Pages
 First install angular-cli-ghpages.
+
 ```
 npm i -g angular-cli-ghpages
 ```
-Then Simply Run:
+
+Then simply run:
+
 ```
-ng build --prod
+ng build --prod --base-href="/[your-repo-name]/"
 angular-cli-ghpages
 ```
-
-**Note:** If you have multifactor authentication enabled for your GitHub account, you must disable it to publish through the CLI. 
 
 Your app will be available at https://[your-GH-username].github.io/[repo-name]
 

--- a/deploy_to_githubpages.md
+++ b/deploy_to_githubpages.md
@@ -40,4 +40,9 @@ Then Simply Run:
 ng build --prod
 angular-cli-ghpages
 ```
+
+**Note:** If you have multifactor authentication enabled for your GitHub account, you must disable it to publish through the CLI. 
+
+Your app will be available at https://[your-GH-username].github.io/[repo-name]
+
 For more information see https://github.com/angular-buch/angular-cli-ghpages.

--- a/local_storage.md
+++ b/local_storage.md
@@ -323,7 +323,7 @@ Now we have one last modification to make. Open up `list-manager.component.ts`, 
 
 ```
 addItem(title:string) {
-    this.todoList = this.todoListService.addItem({ title: title });
+    this.todoList = this.todoListService.addItem({ title });
 }
 ```
 

--- a/local_storage.md
+++ b/local_storage.md
@@ -323,7 +323,7 @@ Now we have one last modification to make. Open up `list-manager.component.ts`, 
 
 ```
 addItem(title:string) {
-    this.todoList = this.todoListService.addItem({ title });
+    this.todoList = this.todoListService.addItem({ title: title });
 }
 ```
 

--- a/remove_item.md
+++ b/remove_item.md
@@ -32,12 +32,14 @@ removeItem() {
 
 Now that each todo item can emit its own removal, let's make sure that the list manager actually removes that same item from the list. For that, we'll work on the file *list-manager.component.ts*.
 
-(a) We need to respond to **remove** event - let's add it to the template, inside the *<todo-item>* tag:
+(a) We need to respond to **remove** event - let's add it to the template, inside the `<todo-item>` tag:
+
 ```
 (remove)="removeItem($event)"
 ```
 
 (b) Now we just need to add the function *removeItem()* to the ListManagerComponent class:
+
 ```
 removeItem(item) {
   this.todoList = this.todoListService.removeItem(item);
@@ -54,13 +56,4 @@ removeItem(item) {
 }
 ```
 
-### File: todo-list-storage.service.ts
-
-Now let's make sure that the storage service removes the item from the storage. In file *todo-list-storage.service.ts*, add the destroy() function to the TodoListStorageService class:
-
-```
-destroy(item) {
-  this.todoList.splice(this.todoList.indexOf(item), 1);
-  return this.update();
-}
-```
+This function calls the destroy() method we already created in  todo-list-storage.service.ts earlier.

--- a/remove_item.md
+++ b/remove_item.md
@@ -33,13 +33,11 @@ removeItem() {
 Now that each todo item can emit its own removal, let's make sure that the list manager actually removes that same item from the list. For that, we'll work on the file *list-manager.component.ts*.
 
 (a) We need to respond to **remove** event - let's add it to the template, inside the `<todo-item>` tag:
-
 ```
 (remove)="removeItem($event)"
 ```
 
 (b) Now we just need to add the function *removeItem()* to the ListManagerComponent class:
-
 ```
 removeItem(item) {
   this.todoList = this.todoListService.removeItem(item);

--- a/service.md
+++ b/service.md
@@ -16,10 +16,13 @@ Provide in ngModule
 ------------
 Now, to start using the service, we first need to provide it in the @NgModule component.
 In /src/app/app.module.ts , add an import code:
+
 ```javascript
 import { TodoListService } from './todo-list.service';
 ```
+
 And now add the service to the "providers" array, that the ngModule component will look like this:
+
 ```javascript
 @NgModule({
   declarations: [
@@ -29,20 +32,19 @@ And now add the service to the "providers" array, that the ngModule component wi
     ListManagerComponent
   ],
   imports: [
-    BrowserModule,
-    FormsModule,
-    HttpModule
+    BrowserModule
   ],
   providers: [TodoListService],
   bootstrap: [AppComponent]
 })
-````
+```
 
 That will allow us to create the service instance and to use it in any place of our app.
 
 Move list from component to service
 ------------
 We now need to move the todoList array from the component to our new service. The service will now have:
+
 ```javascript
 private todoList = [
     { title: 'install NodeJS' },
@@ -57,6 +59,7 @@ private todoList = [
 Create method on service to return the list
 ------------
 Now go to the generated service file, found in src/app/todo-list.service.ts , and add a "getTodoList" function that will return the todoList array. The service will look like this:
+
 ```javascript
 import { Injectable } from '@angular/core';
 
@@ -84,11 +87,13 @@ export class TodoListService {
 Inject to list-manager component and use the service 
 ------------
 After creating the service instance, we can inject it to our list-manager component. Go to /src/app/list-manager/list-manager.component.ts file and add the folllowing import code:
+
 ```javascript
 import { TodoListService } from '../todo-list.service'; 
-````
+```
 
 And just use it in ListManagerComponent class: Remove the todoList array but keep the todoList member and change the constructor to be:
+
 ```javascript
 constructor(private todoListService:TodoListService) { }
 ```


### PR DESCRIPTION
Found many issues and fixed them, such as:

* FormsModule and HttpModule are no longer automatically included by the CLI
* Summary TOC has an incorrect link to adding checkbox file, which makes that section of the tutorial gitbook inaccessible
* `btnRed` was used in template, but the class in CSS is `btn-red`
* A property was marked as private but should be public, since it's used in a template; leaving it private breaks the production build
* Fixed minor typos and formatting issues where tags were being omitted in gitbook because they were not escaped with backticks
* Deploying to GH Pages uses the wrong base href as-is; added a `--base-href` flag that corrects the path so the deployed app will properly reference its scripts
* (and more)

NOTE: adding types to properties that have an initial value is no longer necessary and will produce warnings. The type is inferred automatically if a value is provided. I did not update this throughout the tutorial, but mentors and mentees should be made aware.