### PR TITLE
removed unused imports

### DIFF
--- a/service.md
+++ b/service.md
@@ -29,9 +29,7 @@ And now add the service to the "providers" array, that the ngModule component wi
     ListManagerComponent
   ],
   imports: [
-    BrowserModule,
-    FormsModule,
-    HttpModule
+    BrowserModule
   ],
   providers: [TodoListService],
   bootstrap: [AppComponent]


### PR DESCRIPTION
The FormsModule and HttpModule are not yet necessary for the tutorial.
And not automatically imported:

import { FormsModule } from '@angular/forms';
import { HttpModule } from '@angular/http';

That's confusing, maybe in a later Tutorial one could write a Service calling a REST API and then you'll need the HttpModule and RxJS. Or having a tutorial for Form Validation.



