### PR TITLE
Service AddItem function fix

### DIFF
--- a/add_more_abilities_to_service.md
+++ b/add_more_abilities_to_service.md
@@ -7,7 +7,7 @@ First, lets open our app's service file which is available at - `app/todo-list.s
 There we'll add a new function to the service, called `addItem`, like so:
 ```javascript
 addItem(item): void { 
-    this.todoList.push(item); 
+    this.todoList.push({title: item}); 
 } 
 ```
 


### PR DESCRIPTION
If we push only `item`, adding items doesn't work correctly at this point, pushing `{title: item}` fixes it. 