### PR TITLE
List Manager AddItem function fix

### DIFF
--- a/local_storage.md
+++ b/local_storage.md
@@ -323,7 +323,7 @@ Now we have one last modification to make. Open up `list-manager.component.ts`, 
 
 ```
 addItem(title:string) {
-    this.todoList = this.todoListService.addItem({ item:title });
+    this.todoList = this.todoListService.addItem({ title });
 }
 ```
 


### PR DESCRIPTION
Adding `item: title` doesn't work correctly. As far as I understand we could also change the function in list-manager to pass the item and then in local storage push `item: title`.