### PR TITLE
Fix --inline-template setting for v6

### DIFF
--- a/component.md
+++ b/component.md
@@ -155,7 +155,7 @@ If you wish to continue this tutorial with templates in separate HTML files, do 
 > **Note: **You can specify that you'd like to use inline-template throughout the project in several ways:
 >
 > * When generating a project, pass the flag `-it` or `--inline-template` like this: `ng new todo-list -it`
-> * After generating a project, add it to the configuration so that components generated from this point on will have an inline template: `ng set defaults.component.inlineTemplate true`. \(From version 6 you'll need to use the command `ng config projects.YOURPROJECTNAME.schematics.@schematics/angular:component.inlineTemplate false` instead\) This adds the line `inlineTemplate: true` in the Angular CLI configuration file `.angular-cli.json` \(`angular.json` in version 6\). You can also edit the file directly.
+> * After generating a project, add it to the configuration so that components generated from this point on will have an inline template: `ng set defaults.component.inlineTemplate true`. \(From version 6 you'll need to use the command `ng config projects.YOURPROJECTNAME.schematics.@schematics/angular:component.inlineTemplate true` instead\) This adds the line `inlineTemplate: true` in the Angular CLI configuration file `.angular-cli.json` \(`angular.json` in version 6\). You can also edit the file directly.
 > * If you haven't configured to have inline templates as a default, you can specify this per component when you generate it, by passing the flag `-it` or `--inline-template`. For example: `ng generate header -it`.
 
 The same way we use inline template, we can use also inline styles. But for now we will keep the styles in a separate file.

--- a/component.md
+++ b/component.md
@@ -155,7 +155,7 @@ If you wish to continue this tutorial with templates in separate HTML files, do 
 > **Note: **You can specify that you'd like to use inline-template throughout the project in several ways:
 >
 > * When generating a project, pass the flag `-it` or `--inline-template` like this: `ng new todo-list -it`
-> * After generating a project, add it to the configuration so that components generated from this point on will have an inline template: `ng set defaults.component.inlineTemplate true`. \(From version 6 you'll be able to use the command `config` instead of `set`.\) This adds the line `inlineTemplate: true` in the Angular CLI configuration file `.angular-cli.json`. You can also edit the file directly.
+> * After generating a project, add it to the configuration so that components generated from this point on will have an inline template: `ng set defaults.component.inlineTemplate true`. \(From version 6 you'll need to use the command `ng config projects.YOURPROJECTNAME.schematics.@schematics/angular:component.inlineTemplate false` instead\) This adds the line `inlineTemplate: true` in the Angular CLI configuration file `.angular-cli.json` \(`angular.json` in version 6\). You can also edit the file directly.
 > * If you haven't configured to have inline templates as a default, you can specify this per component when you generate it, by passing the flag `-it` or `--inline-template`. For example: `ng generate header -it`.
 
 The same way we use inline template, we can use also inline styles. But for now we will keep the styles in a separate file.


### PR DESCRIPTION
After v6 release the note is no longer accurate. The new command is a bit more involved.