### PR TITLE
Clean up component example so it can be copied

### DIFF
--- a/interface.md
+++ b/interface.md
@@ -1,6 +1,6 @@
 # Interface
 
-We want to use TypeScript's abilities to know what kind of object we pass as an `item` to the `todo-item` component. We'll make sure that the item is of the right type. But its type is not a simple string, number or boolean. We'll define the item's type using can **interface**. 
+We want to use TypeScript's abilities to know what kind of object we pass as an `item` to the `todo-item` component. We'll make sure that the item is of the right type. But its type is not a simple string, number or boolean. We'll define the item's type using can **interface**.
 
 > We've already seen an interface provided by Angular: the `OnInit` interface which includes the method `ngOnInit`. Every Class that implements this interface should define this method. Otherwise we'll get an error during compile time.
 >
@@ -28,7 +28,7 @@ export interface TodoItem {
 Now we can define what properties and/or methods every object of type TodoItem should have. At this point we'll add two members:
 
 * `title` which must be of type `string`
-* `completed` which is of type `boolean` and is an optional member 
+* `completed` which is of type `boolean` and is an optional member
 
 {% code-tabs %}
 {% code-tabs-item title="src/app/interfaces/todo-item.ts" %}
@@ -68,15 +68,16 @@ Now, let's define the list of todo items to contain objects of the `TodoItem` ty
 {% code-tabs-item title="src/app/app.component.ts" %}
 ```typescript
 export class AppComponent {
-title = 'app';
-todoList: TodoItem[] = [
-  {title: 'install NodeJS'},
-  {title: 'install Angular CLI'},
-  {title: 'create new app'},
-  {title: 'serve app'},
-  {title: 'develop app'},
-  {title: 'deploy app'},
-];
+  title = 'app';
+  todoList: TodoItem[] = [
+    {title: 'install NodeJS'},
+    {title: 'install Angular CLI'},
+    {title: 'create new app'},
+    {title: 'serve app'},
+    {title: 'develop app'},
+    {title: 'deploy app'},
+  ];
+}
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}


### PR DESCRIPTION
There is a closing brace missing from the component example which is problematic
when copy/pasting.