### PR TITLE
refactor: add a note about the NG 7 CLI prompts

### DIFF
--- a/installations.md
+++ b/installations.md
@@ -117,7 +117,8 @@ ng new todo-list
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-This can take a while, since many packages are being downloaded from the web and installed.
+If you are prompted for additional information, accept the defaults by pressing the Enter or Return key.
+Running the command can take a while, since many packages are being downloaded from the web and installed.
 
 Now enter the new folder that the Angular CLI created for this project:
 


### PR DESCRIPTION
When creating new projects with Angular CLI 7.0+, the users are prompted for information about the features that they want in their project (routing, stylesheet).
For this tutorial, the defaults (no routing, CSS) would work just fine.