### PR TITLE
Rename angular-cli.json to angular.json

### DIFF
--- a/appendix-1-generating-a-new-project.md
+++ b/appendix-1-generating-a-new-project.md
@@ -29,7 +29,7 @@ from that point the Angular CLI will download all the dependencies and install t
 after we created the project we will get file in this format
 
 ```text
-├── angular-cli.json // Angular CLI configuration
+├── angular.json // Angular CLI configuration
 ├── e2e // end to end testing
 ├── karma.conf.js // testing configuration file
 ├── package.json // package configuration file


### PR DESCRIPTION
angular-cli.json is deprecated and replaced by angular.json on Angular v6+
https://blog.ninja-squad.com/2018/05/04/angular-cli-6.0/